### PR TITLE
fix #83

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ node_modules
 # Debug files
 debug
 .DS_Store
+
+# IDE settings
+.idea
+.vscode

--- a/lib/RTSPClient.ts
+++ b/lib/RTSPClient.ts
@@ -156,6 +156,12 @@ export default class RTSPClient extends EventEmitter {
         reject(err);
       };
 
+      const postConnectErrorListener = (err: any) => {
+        client.removeListener("error", postConnectErrorListener);
+        this.emit("error", err);
+        reject(err);
+      };
+
       const closeListener = () => {
         client.removeListener("close", closeListener);
         this.close(true);
@@ -183,6 +189,7 @@ export default class RTSPClient extends EventEmitter {
         this._client = client;
 
         client.removeListener("error", errorListener);
+        client.on("error", postConnectErrorListener);
 
         this.on("response", responseListener);
         resolve(this);
@@ -671,7 +678,7 @@ export default class RTSPClient extends EventEmitter {
     if (!this._client) {
       return;
     }
-    
+
     if (!isImmediate) {
       await this.request("TEARDOWN", {
         Session: this._session,

--- a/lib/RTSPClient.ts
+++ b/lib/RTSPClient.ts
@@ -164,6 +164,7 @@ export default class RTSPClient extends EventEmitter {
 
       const closeListener = () => {
         client.removeListener("close", closeListener);
+        this.emit("close");
         this.close(true);
       };
 


### PR DESCRIPTION
## Description

node.js that using RTSPClient crashes when ECONNRESET of RTSPServer because it does not handles that error.
fixed RTSPClient.ts

1. emit "error" event to handle errors after connection(including ECONNRESET
2. emit "close" event when RTSPClient closes its connection for better debugging

if this pull request merges, users can handle ECONNRESET by

```ts
const client = new RTSPClient(username, password);
client.on("error", () => { // reconnect or something });
```

## Related Issue

Fixes #83 
